### PR TITLE
fix: properly extract flux binary

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -9,15 +9,13 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
-
-# TODO: Adapt this to proper extension and adapt extracting strategy.
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 
 # Download tar.gz file to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
 #  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 
 # Remove the tar.gz file since we don't need to keep it
 rm "$release_file"

--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,6 @@ Testing Locally:
 ```shell
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
-# TODO: adapt this
 asdf plugin test flux2 https://github.com/rahulsmehta/asdf-flux2.git "flux version --client"
 ```
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-# TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for flux2.
 GH_REPO="https://github.com/fluxcd/flux2"
 TOOL_NAME="flux"
 TOOL_TEST="flux version --client"
@@ -47,8 +46,10 @@ download_release() {
 	# https://github.com/fluxcd/flux2/releases/download/v2.3.0/flux_2.3.0_darwin_amd64.tar.gz
 	url="$GH_REPO/releases/download/v${version}/flux_${version}_${variant}.tar.gz"
 
-	echo "* Downloading $TOOL_NAME release $version..."
+	echo "* Downloading $TOOL_NAME release $version... to $filename from $url"
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+	ls "$filename"
+	stat "$filename"
 }
 
 install_version() {


### PR DESCRIPTION
## Summary
This PR fixes extracting the `flux` binary when running the asdf setup script.

## Test Plan
CI