### PR TITLE
Verify release checksums during installation

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -10,9 +10,11 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
+checksum_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.checksums.txt"
 
-# Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+# Download tar.gz file to the download directory & verify against checksum
+download_release "$ASDF_INSTALL_VERSION" "$release_file" "$checksum_file"
+verify_release "$release_file" "$checksum_file"
 
 #  Extract contents of tar.gz file into the download directory
 tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -33,7 +33,7 @@ list_all_versions() {
 }
 
 download_release() {
-	local version release_filename checksum_filename 
+	local version release_filename checksum_filename
 	local url_base release_url checksum_url platform arch variant
 
 	version="$1"
@@ -55,25 +55,24 @@ download_release() {
 	curl "${curl_opts[@]}" -o "$release_filename" -C - "$release_url" || fail "Could not download $release_url"
 
 	echo "* Downloading checksums..."
-	curl "${curl_opts[@]}" -o "$checksum_filename" -C -  "$checksum_url" || fail "Could not download $checksum_url"
+	curl "${curl_opts[@]}" -o "$checksum_filename" -C - "$checksum_url" || fail "Could not download $checksum_url"
 }
 
 compute_sha256sum() {
 	local cmd
-  cmd=$(which sha256sum shasum | head -n 1)
-  case $(basename "$cmd") in
-    sha256sum)
-      sha256sum "$1" | cut -f 1 -d ' '
-      ;;
-    shasum)
-      shasum -a 256 "$1" | cut -f 1 -d ' '
-      ;;
-    *)
-      fail "Can not find sha256sum or shasum to compute checksum"
-      ;;
-  esac
+	cmd=$(which sha256sum shasum | head -n 1)
+	case $(basename "$cmd") in
+	sha256sum)
+		sha256sum "$1" | cut -f 1 -d ' '
+		;;
+	shasum)
+		shasum -a 256 "$1" | cut -f 1 -d ' '
+		;;
+	*)
+		fail "Can not find sha256sum or shasum to compute checksum"
+		;;
+	esac
 }
-
 
 verify_release() {
 	local release_filename checksum_filename
@@ -82,11 +81,11 @@ verify_release() {
 	release_filename="$1"
 	checksum_filename="$2"
 
-	expected_checksum=$(cat "$checksum_filename" | grep "$RELEASE_ARTIFACT_FILENAME" | cut -d' ' -f1)
+	expected_checksum=$(grep "$RELEASE_ARTIFACT_FILENAME" "$checksum_filename" | cut -d' ' -f1)
 	release_checksum=$(compute_sha256sum "$release_filename")
 
 	if [[ "$expected_checksum" != "$release_checksum" ]]; then
-		fail "Expected sha256sum does not match "$expected_checksum", got $release_checksum"
+		fail "Expected sha256sum does not match $expected_checksum, got $release_checksum"
 	fi
 }
 


### PR DESCRIPTION
## Before this change

The installer didn't verify the downloaded artifact against the checksums with the release

## After this change
Install script verifies the downloaded artifact against release checksum

## Test Plan
CI